### PR TITLE
KeywordRepliesController へのリクエストに Basic 認証をかける

### DIFF
--- a/app/controllers/keyword_replies_controller.rb
+++ b/app/controllers/keyword_replies_controller.rb
@@ -1,4 +1,6 @@
 class KeywordRepliesController < ApplicationController
+  before_filter :basic_auth
+
   def index
     @keyword_replies = KeywordReply.all
   end
@@ -52,6 +54,12 @@ class KeywordRepliesController < ApplicationController
   end
 
   private
+  def basic_auth
+    authenticate_or_request_with_http_basic do |user, pass|
+      user == ENV["BASIC_AUTH_USER"] && pass == ENV["BASIC_AUTH_PASS"]
+    end
+  end
+
   def keyword_reply_params
     params.require(:keyword_reply).permit(:keyword, :reply_type, :reply_word)
   end


### PR DESCRIPTION
authenticate_or_request_with_http_basic を使用した Basic 認証を設定
* KeywordRepliesController にのみ
* user と pass は環境変数に設定する